### PR TITLE
Integrate Pragmatic Programmer principles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,8 @@ code-style/
   vanilla-extract-css.why.md     # rationale
 best-practices/
   _index.md                      # guide status
+  architecting-features.md       # rules
+  architecting-features.why.md   # rationale
   refactoring.md                 # rules
   refactoring.why.md             # rationale
   testing.md                     # rules

--- a/README.md
+++ b/README.md
@@ -24,15 +24,16 @@ For the framing behind all of this — why tending a codebase matters more than 
 
 These guides are structured for lazy loading — don't read the whole repo, read the file that maps to your current task:
 
-| Task                           | File                                                                     |
-| ------------------------------ | ------------------------------------------------------------------------ |
-| Writing TypeScript             | [code-style/typescript.md](./code-style/typescript.md)                   |
-| Writing React                  | [code-style/react.md](./code-style/react.md)                             |
-| Writing CSS (any tool)         | [code-style/css.md](./code-style/css.md)                                 |
-| Writing Vanilla Extract styles | [code-style/vanilla-extract-css.md](./code-style/vanilla-extract-css.md) |
-| Writing tests                  | [best-practices/testing.md](./best-practices/testing.md)                 |
-| Refactoring                    | [best-practices/refactoring.md](./best-practices/refactoring.md)         |
-| Language-agnostic principles   | [philosophy.md](./philosophy.md)                                         |
+| Task                           | File                                                                                 |
+| ------------------------------ | ------------------------------------------------------------------------------------ |
+| Writing TypeScript             | [code-style/typescript.md](./code-style/typescript.md)                               |
+| Writing React                  | [code-style/react.md](./code-style/react.md)                                         |
+| Writing CSS (any tool)         | [code-style/css.md](./code-style/css.md)                                             |
+| Writing Vanilla Extract styles | [code-style/vanilla-extract-css.md](./code-style/vanilla-extract-css.md)             |
+| Writing tests                  | [best-practices/testing.md](./best-practices/testing.md)                             |
+| Refactoring                    | [best-practices/refactoring.md](./best-practices/refactoring.md)                     |
+| Architecting features          | [best-practices/architecting-features.md](./best-practices/architecting-features.md) |
+| Language-agnostic principles   | [philosophy.md](./philosophy.md)                                                     |
 
 Rules files (`*.md`) are self-contained. Rationale files (`*.why.md`) are optional — read them only when an edge case or judgment call needs more context. Individual rationale sections are anchor-linked from the rules files, so you can pull one section (`typescript.why.md#types-vs-interfaces`) without loading the whole file.
 

--- a/best-practices/_index.md
+++ b/best-practices/_index.md
@@ -4,7 +4,8 @@ Process, workflow, testing, and operational practices. Rules files follow the sa
 
 ## Available Guides
 
-| Guide       | Rules                              | Rationale                                  | Status   |
-| ----------- | ---------------------------------- | ------------------------------------------ | -------- |
-| Refactoring | [refactoring.md](./refactoring.md) | [refactoring.why.md](./refactoring.why.md) | Complete |
-| Testing     | [testing.md](./testing.md)         | [testing.why.md](./testing.why.md)         | Complete |
+| Guide                 | Rules                                                  | Rationale                                                      | Status   |
+| --------------------- | ------------------------------------------------------ | -------------------------------------------------------------- | -------- |
+| Architecting Features | [architecting-features.md](./architecting-features.md) | [architecting-features.why.md](./architecting-features.why.md) | Complete |
+| Refactoring           | [refactoring.md](./refactoring.md)                     | [refactoring.why.md](./refactoring.why.md)                     | Complete |
+| Testing               | [testing.md](./testing.md)                             | [testing.why.md](./testing.why.md)                             | Complete |

--- a/best-practices/architecting-features.md
+++ b/best-practices/architecting-features.md
@@ -1,0 +1,13 @@
+# Architecting Features
+
+Rationale for the opinionated sections lives in [architecting-features.why.md](./architecting-features.why.md). Strength levels (`non-negotiable` / `strong` / `weak`) are defined in [../code-style/\_index.md](../code-style/_index.md).
+
+## Prove the Pipeline Early
+
+`strength: strong` · [rationale](./architecting-features.why.md#prove-the-pipeline-early)
+
+Build a thin end-to-end slice first — UI → state → API → data — before filling out any layer in full. The slice uses real components, real routes, real endpoints. It is not a prototype.
+
+- Wire the UI to the API before writing business logic. A form that roundtrips to a real endpoint surfaces integration problems while the system is still cheap to change.
+- Prefer a working-but-incomplete vertical slice over a complete-but-unconnected horizontal layer.
+- The slice is production-bound code. Flesh it out; don't throw it away.

--- a/best-practices/architecting-features.why.md
+++ b/best-practices/architecting-features.why.md
@@ -1,0 +1,25 @@
+# Architecting Features — Rationale
+
+Expanded rationale for opinionated rules in [architecting-features.md](./architecting-features.md). Section names mirror the rules file.
+
+---
+
+## Prove the Pipeline Early
+
+**Rule:** Build a thin end-to-end slice first before filling out any layer in full.
+
+**Strength:** strong
+
+Adapted from [_The Pragmatic Programmer_, Hunt & Thomas](https://pragprog.com/titles/tpp20/the-pragmatic-programmer-20th-anniversary-edition/) — "Tracer Bullets" chapter.
+
+### The integration tax is cheapest early
+
+The failure mode this rule guards against: discovering integration mismatches after each layer is complete. Fixing a mismatch between a finished API and a finished UI is far more expensive than catching it when both are thin. The thin slice is the tracer — it traces a path through the real system and shows immediately where something doesn't connect.
+
+### Tracer bullets, not prototypes
+
+Hunt & Thomas draw a sharp distinction. A prototype is written to be thrown away — exploratory, unpolished, expected to be discarded. A tracer slice is production code: it has tests, follows conventions, and ships. The difference is scope (thin) not quality.
+
+### Working horizontally is locally efficient and globally costly
+
+The common alternative: build all API endpoints before touching the UI. Less context-switching per session — but you pay the integration tax at the end, when every layer is already optimized in isolation and the blast radius of a mismatch is largest.

--- a/code-gardening.md
+++ b/code-gardening.md
@@ -6,9 +6,17 @@ Software isn't a static structure; it's a living ecosystem. The "building" metap
 
 A plant is only as healthy as the soil it grows in. In a codebase, your "soil" is your infrastructure, CI/CD pipelines, and core architectural patterns. If the environment is depleted—meaning brittle tests, inconsistent DX, or poor documentation—even the best features will eventually rot. Invest in the soil so that everything else has a chance to thrive.
 
-### Pruning is Mandatory
+### Weeding is Mandatory
 
-A garden left alone quickly becomes a thicket. In software, "weeds" are technical debt, dead code, and outdated dependencies. Pruning isn't a sign that something went wrong; it’s a requirement for the system to survive. You have to be disciplined about cutting back what no longer serves the codebase to make room for new growth.
+A garden left alone quickly becomes a thicket. In software, "weeds" are the things that actively harm the codebase: technical debt, dead code, outdated dependencies, and broken windows. Weeding isn’t a sign that something went wrong; it’s a requirement for the system to survive.
+
+The harder problem is compounding decay. A broken window left unfixed signals that decay is acceptable — and that signal spreads. One ignored `TODO`, one commented-out block, one dependency three major versions behind, and the team stops noticing. If you can’t fix a broken window immediately, ticket it or quarantine it so the decay doesn’t normalize.
+
+### Pruning is Important
+
+Weeding is reactive — it removes what’s broken or rotting. Pruning is proactive — it cuts back what’s healthy but overgrown: unused feature flags, kept-just-in-case abstractions, safety nets no one is tripping anymore.
+
+Left to accumulate, overgrowth costs the same as weeds: slower reads, higher cognitive load, more code to change when the system shifts. Prune before it hardens into load-bearing complexity.
 
 ### Intentional Cultivation
 

--- a/code-gardening.md
+++ b/code-gardening.md
@@ -2,21 +2,23 @@
 
 Software isn't a static structure; it's a living ecosystem. The "building" metaphor is a trap—it implies that once the last brick is laid, you're done. In reality, large-scale engineering is about continuous maintenance. We don't just build systems; we tend to them.
 
-### Infrastructure as Soil Health
-
-A plant is only as healthy as the soil it grows in. In a codebase, your "soil" is your infrastructure, CI/CD pipelines, and core architectural patterns. If the environment is depleted—meaning brittle tests, inconsistent DX, or poor documentation—even the best features will eventually rot. Invest in the soil so that everything else has a chance to thrive.
-
 ### Weeding is Mandatory
 
 A garden left alone quickly becomes a thicket. In software, "weeds" are the things that actively harm the codebase: technical debt, dead code, outdated dependencies, and broken windows. Weeding isn’t a sign that something went wrong; it’s a requirement for the system to survive.
 
-The harder problem is compounding decay. A broken window left unfixed signals that decay is acceptable — and that signal spreads. One ignored `TODO`, one commented-out block, one dependency three major versions behind, and the team stops noticing. If you can’t fix a broken window immediately, ticket it or quarantine it so the decay doesn’t normalize.
+A weed left un-pulled eventually goes to seed — and that seed spreads to create more weeds, leading to systemic issues that are much harder to root out. One ignored `TODO`, one commented-out block, one dependency three major versions behind, and the team stops noticing. If you can’t pull a weed immediately, ticket it or quarantine it so the decay doesn’t normalize.
+
+Adapted from the "Broken Windows" theory.
 
 ### Pruning is Important
 
 Weeding is reactive — it removes what’s broken or rotting. Pruning is proactive — it cuts back what’s healthy but overgrown: unused feature flags, kept-just-in-case abstractions, safety nets no one is tripping anymore.
 
 Left to accumulate, overgrowth costs the same as weeds: slower reads, higher cognitive load, more code to change when the system shifts. Prune before it hardens into load-bearing complexity.
+
+### Infrastructure as Soil Health
+
+A plant is only as healthy as the soil it grows in. In a codebase, your "soil" is your infrastructure, CI/CD pipelines, and core architectural patterns. If the environment is depleted—meaning brittle tests, inconsistent DX, or poor documentation—even the best features will eventually rot. Invest in the soil so that everything else has a chance to thrive.
 
 ### Intentional Cultivation
 

--- a/inspiration.md
+++ b/inspiration.md
@@ -6,6 +6,7 @@ Few of the opinions in this repo are original. This page collects the source mat
 
 - **_Clean Code_**, Robert C. Martin. Meaningful names, small functions, single responsibility, comments as a failure to express yourself in code.
 - **_On Writing_**, Stephen King. Nothing at all to do with code, inspired the repository name.
+- **_The Pragmatic Programmer_**, Hunt & Thomas. Tracer bullets, broken windows, DRY, orthogonality — the practitioner's handbook.
 
 ## Martin Fowler
 

--- a/inspiration.md
+++ b/inspiration.md
@@ -5,8 +5,8 @@ Few of the opinions in this repo are original. This page collects the source mat
 ## Books
 
 - **_Clean Code_**, Robert C. Martin. Meaningful names, small functions, single responsibility, comments as a failure to express yourself in code.
-- **_On Writing_**, Stephen King. Nothing at all to do with code, inspired the repository name.
 - **_The Pragmatic Programmer_**, Hunt & Thomas. Tracer bullets, broken windows, DRY, orthogonality — the practitioner's handbook.
+- **_On Writing_**, Stephen King. Nothing at all to do with code, inspired the repository name.
 
 ## Martin Fowler
 

--- a/philosophy.md
+++ b/philosophy.md
@@ -14,6 +14,18 @@ Duplicate before you abstract. Two copies of similar code is cheaper than one wr
 
 The failure mode is the abstraction that fits two cases perfectly and fights the third. You end up with conditional flags, optional parameters, and "just for this case" branches — the abstraction costs more than the duplication it replaced.
 
+For the related question of duplicated _knowledge_ rather than duplicated syntax, see [Single Source of Truth](#single-source-of-truth).
+
+## Single Source of Truth
+
+Every piece of domain knowledge — a schema, a constant, a business rule, a validation — has one authoritative representation. When it changes, it changes in exactly one place.
+
+The distinction from AHA: AHA governs syntactic duplication — code that happens to look similar. SSoT governs semantic duplication — a single piece of knowledge expressed in multiple places. Two structurally similar reducers are fine; two copies of the same validation rule are not.
+
+What SSoT rules out: the same enum defined in three files, a magic number repeated across UI and API, business logic split between client and server validation that can drift.
+
+What SSoT does not rule out: two similar-looking reducer cases, two API handlers with similar shape, two React components that happen to render the same DOM. Similar structure is not shared knowledge.
+
 ## Don't Solve Problems You Don't Have
 
 A specific target within YAGNI: invented problems. _"What if we need to swap databases?" "What if we scale 10x?" "What if we go multi-region?"_ If none of those are on the horizon, the abstraction you build for them is speculation — and most speculation is wrong.
@@ -51,6 +63,14 @@ Organizing by "kind" (all styles in `styles/`, all tests in `tests/`) optimizes 
 Colocation scales down too: a helper used only by one module belongs in that module, not in a shared `utils/`. Promote to a shared location only when it has a real second caller.
 
 When you do promote, put the shared code in a `common/` (or `shared/`) directory at the closest scope that makes sense. A helper used by three files inside `features/checkout/` belongs in `features/checkout/common/`, not a top-level `utils/`. Reserve top-level shared directories for code genuinely used across features — not code that's merely reusable in principle.
+
+## Separate Things That Change Independently
+
+The other side of the colocation axis: things that change for different reasons should not be fused. Changing one concern shouldn't require an edit in another.
+
+Test for coupling: when one concern changes, does an unrelated concern need to change with it? If yes, they were fused, not adjacent.
+
+In practice: hooks return data and components render it; schema validation lives at boundaries; side effects are pushed to the edges. When you pull these apart, each piece can change without touching the others.
 
 ## Make Illegal States Unrepresentable
 


### PR DESCRIPTION
Closes #2.

## What changed

**`code-gardening.md`** — Split "Pruning is Mandatory" into two sections with distinct urgencies:
- "Weeding is Mandatory" — absorbs broken-windows / compounding-decay angle from the issue
- "Pruning is Important" — proactive cutting of healthy-but-overgrown code

**`philosophy.md`** — Two new sections:
- "Single Source of Truth" (after AHA) — governs duplicated _knowledge_, not duplicated syntax; explicit AHA-vs-SSoT contrast included, with a pointer added to the AHA section
- "Separate Things That Change Independently" (after "Colocate Things That Change Together") — orthogonality as the coupling half of the cohesion/coupling pair

**`best-practices/architecting-features.md` + `.why.md`** — New guide, first rule "Prove the Pipeline Early" (tracer bullets). Placed in `best-practices/` because it governs feature staging over time, not individual code shape. Rationale cites Hunt & Thomas.

**Skipped:** Design by contract (proposal #4) — already implicit across `Make Illegal States Unrepresentable`, `any`/`unknown`, `as` casting, and strict mode in `typescript.md`.

**Navigation updates:** `best-practices/_index.md`, `README.md`, `CLAUDE.md` structure tree, `inspiration.md`.

## Test plan

- [ ] All anchor links from rules files resolve to matching sections in `.why` siblings
- [ ] New `philosophy.md` sections read as rules (no "because…" prose that belongs in a `.why`)
- [ ] "Separate Things" and "Colocate Things" sit adjacent and read as a coherent pair, not a contradiction
- [ ] SSoT section survives a cold read without confusing the reader vs. AHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)